### PR TITLE
Build improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ composer.lock
 
 # OS X
 **/.DS_Store
+
+resources/models/raw

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ This README is divided into several sections:
 * [Naming conventions](#naming-conventions)
 * [API versions](#api-versions)
 * [Working with DTOs](#working-with-dtos)
+* [Contributing](#contributing)
 
 ## Getting Started
 
@@ -540,3 +541,19 @@ $response = $ordersApi->confirmShipment(
     confirmShipmentRequest: $confirmShipmentRequest,
 )
 ```
+
+## Contributing
+
+To regenerate the library, you can run 
+
+    # composer clean
+    # composer build
+
+Composer has a number of pre-configured scripts in `composer.json`:
+
+* `build`: Run all the stages to regenerate the PHP files
+* `clean`: Delete all the generated PHP and JSON files
+* `lint`: Run PHP-CS-Fixer 
+* `schema:download`: Download the schemas from Amazon
+* `schema:generate`: Generate the PHP files from the schemas
+* `schema:refactor`: Make local modifications to the schemas before generation

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,10 @@
     "require": {
         "php": ">=8.1",
         "ext-curl": "*",
+        "ext-dom": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
+        "ext-simplexml": "*",
         "guzzlehttp/guzzle": "^6.0|^7.0",
         "saloonphp/saloon": "^3.4",
         "openspout/openspout": "^4.23",
@@ -54,6 +56,13 @@
         }
     },
     "scripts": {
+        "build": [
+            "@schema:download",
+            "@schema:refactor",
+            "@schema:generate",
+            "@lint"
+        ],
+        "clean": "rm -rf src/Vendor src/Seller resources/models/seller resources/models/vendor resources/models/raw",
         "lint": [
             "@pint",
             "@php-compatibility-check"
@@ -61,7 +70,10 @@
         "pint": "php vendor/bin/pint",
         "php-compatibility-check": "./vendor/bin/phpcs -p ./src ./bin --standard=PHPCompatibility --runtime-set testVersion 8.1-",
         "post-install-cmd": "\"vendor/bin/phpcs\" --config-set installed_paths vendor/phpcompatibility/php-compatibility",
-        "post-update-cmd": "\"vendor/bin/phpcs\" --config-set installed_paths vendor/phpcompatibility/php-compatibility"
+        "post-update-cmd": "\"vendor/bin/phpcs\" --config-set installed_paths vendor/phpcompatibility/php-compatibility",
+        "schema:download": "@php bin/console schema:download",
+        "schema:generate": "@php bin/console schema:generate",
+        "schema:refactor": "@php bin/console schema:refactor"
     },
     "config": {
         "allow-plugins": {

--- a/resources/models/raw/.gitignore
+++ b/resources/models/raw/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
This adds a `build` and `clean` commands to `composer.json` to enable easier discovery of the build process for new developers.

Due to the `clean` deleting the raw directory. I've moved the gitignore into the top level `.gitignore`.

The available commands are added to the README.md