### PR TITLE
Remove Shipment Address required values

### DIFF
--- a/resources/metadata/modifications.json
+++ b/resources/metadata/modifications.json
@@ -1,5 +1,14 @@
 {
   "seller": {
+    "fba-inbound": {
+      "0": [
+        {
+          "comment": "Responses from Amazon have been missing one or more required Address parts",
+          "action": "delete",
+          "path": "components.schemas.Address.required"
+        }
+      ]
+    },
     "orders": {
       "0": [
         {

--- a/resources/models/seller/fba-inbound/v0.json
+++ b/resources/models/seller/fba-inbound/v0.json
@@ -4808,14 +4808,6 @@
                 }
             },
             "Address": {
-                "required": [
-                    "AddressLine1",
-                    "City",
-                    "CountryCode",
-                    "Name",
-                    "PostalCode",
-                    "StateOrProvinceCode"
-                ],
                 "type": "object",
                 "properties": {
                     "Name": {

--- a/src/Seller/FBAInboundV0/Dto/Address.php
+++ b/src/Seller/FBAInboundV0/Dto/Address.php
@@ -11,37 +11,37 @@ final class Address extends Dto
     protected static array $attributeMap = [
         'name' => 'Name',
         'addressLine1' => 'AddressLine1',
+        'addressLine2' => 'AddressLine2',
+        'districtOrCounty' => 'DistrictOrCounty',
         'city' => 'City',
         'stateOrProvinceCode' => 'StateOrProvinceCode',
         'countryCode' => 'CountryCode',
         'postalCode' => 'PostalCode',
-        'addressLine2' => 'AddressLine2',
-        'districtOrCounty' => 'DistrictOrCounty',
     ];
 
     /**
-     * @param  string  $name  Name of the individual or business.
-     * @param  string  $addressLine1  The street address information.
-     * @param  string  $city  The city.
-     * @param  string  $stateOrProvinceCode  The state or province code.
-     *
-     * If state or province codes are used in your marketplace, it is recommended that you include one with your request. This helps Amazon to select the most appropriate Amazon fulfillment center for your inbound shipment plan.
-     * @param  string  $countryCode  The country code in two-character ISO 3166-1 alpha-2 format.
-     * @param  string  $postalCode  The postal code.
-     *
-     * If postal codes are used in your marketplace, we recommended that you include one with your request. This helps Amazon select the most appropriate Amazon fulfillment center for the inbound shipment plan.
+     * @param  ?string  $name  Name of the individual or business.
+     * @param  ?string  $addressLine1  The street address information.
      * @param  ?string  $addressLine2  Additional street address information, if required.
      * @param  ?string  $districtOrCounty  The district or county.
+     * @param  ?string  $city  The city.
+     * @param  ?string  $stateOrProvinceCode  The state or province code.
+     *
+     * If state or province codes are used in your marketplace, it is recommended that you include one with your request. This helps Amazon to select the most appropriate Amazon fulfillment center for your inbound shipment plan.
+     * @param  ?string  $countryCode  The country code in two-character ISO 3166-1 alpha-2 format.
+     * @param  ?string  $postalCode  The postal code.
+     *
+     * If postal codes are used in your marketplace, we recommended that you include one with your request. This helps Amazon select the most appropriate Amazon fulfillment center for the inbound shipment plan.
      */
     public function __construct(
-        public readonly string $name,
-        public readonly string $addressLine1,
-        public readonly string $city,
-        public readonly string $stateOrProvinceCode,
-        public readonly string $countryCode,
-        public readonly string $postalCode,
+        public readonly ?string $name = null,
+        public readonly ?string $addressLine1 = null,
         public readonly ?string $addressLine2 = null,
         public readonly ?string $districtOrCounty = null,
+        public readonly ?string $city = null,
+        public readonly ?string $stateOrProvinceCode = null,
+        public readonly ?string $countryCode = null,
+        public readonly ?string $postalCode = null,
     ) {
     }
 }


### PR DESCRIPTION
Data fetched from Amazon for shipments can be missing values. This results in deserialisation errors when Amazon returns data with those fields missing.

Fixes #703